### PR TITLE
Force exit when done

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -4,16 +4,17 @@ var concat = require('concat-stream');
 var request = require('then-request');
 var JSON = require('./json-buffer');
 
+function respond(data) {
+  process.stdout.write(JSON.stringify(data), function() {
+    process.exit(0);
+  });
+}
+
 process.stdin.pipe(concat(function (stdin) {
   var req = JSON.parse(stdin.toString());
   request(req.method, req.url, req.options).done(function (response) {
-    process.stdout.write(JSON.stringify({success: true, response: response}));
+    respond({success: true, response: response});
   }, function (err) {
-    process.stdout.write(JSON.stringify({
-      success: false,
-      error: {
-        message: err.message
-      }
-    }));
+    respond({success: false, error: { message: err.message }});
   });
 }));


### PR DESCRIPTION
* Pins the version of `http-basic` because `http-basic@2.3.2` contains `console.*` statements that break `sync-request`
* Hard exit after printing the data to prevent the process from hanging around

Depending on the node version this can cause a speed difference from half a second up to 16s.