### PR TITLE
Exit the worker process as soon as data is flushed

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -7,13 +7,17 @@ var JSON = require('./json-buffer');
 process.stdin.pipe(concat(function (stdin) {
   var req = JSON.parse(stdin.toString());
   request(req.method, req.url, req.options).done(function (response) {
-    process.stdout.write(JSON.stringify({success: true, response: response}));
+    process.stdout.write(JSON.stringify({success: true, response: response}), function () {
+      process.exit(0);
+    });
   }, function (err) {
     process.stdout.write(JSON.stringify({
       success: false,
       error: {
         message: err.message
       }
-    }));
+    }), function () {
+      process.exit(0);
+    });
   });
 }));


### PR DESCRIPTION
[see #6]

This needs testing on windows, but I think it should work.