### PR TITLE
Add example with options to the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,11 @@ console.log(res.getBody());
 
 ```js
 var request = require('sync-request');
-var opt_obj = {
-	'headers': {
-		'user-agent': 'example-user-agent'
-	}
-};
-var res = request('GET', 'https://example.com');
+var res = request('GET', 'https://example.com', {
+                        'headers': {
+                          'user-agent': 'example-user-agent'
+                        }
+                      });
 console.log(res.getBody());
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,24 @@ request(method, url, options)
 
 e.g.
 
+- GET request without options
+
 ```js
 var request = require('sync-request');
 var res = request('GET', 'http://example.com');
+console.log(res.getBody());
+```
+
+- GET request with options
+
+```js
+var request = require('sync-request');
+var opt_obj = {
+	'headers': {
+		'user-agent': 'example-user-agent'
+	}
+};
+var res = request('GET', 'https://example.com');
 console.log(res.getBody());
 ```
 


### PR DESCRIPTION
- There were no examples in the README that demonstrate how to use the options parameter.