### PR TITLE
Addition of http verb helper methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var JSON = require('./lib/json-buffer');
 Function('', fs.readFileSync(require.resolve('./lib/worker.js'), 'utf8'));
 
 module.exports = doRequest;
+
 function doRequest(method, url, options) {
   if (!spawnSync) {
     throw new Error(
@@ -36,4 +37,20 @@ function doRequest(method, url, options) {
   } else {
     throw new Error(response.error.message || response.error || response);
   }
+}
+
+doRequest.get = function (url, options) {
+	return doRequest('GET', url, options);
+};
+
+doRequest.post = function (url, options) {
+  return doRequest('POST', url, options);
+};
+
+doRequest.put = function (url, options) {
+  return doRequest('PUT', url, options);
+}
+
+doRequest.delete = function (url, options) {
+  return doRequest('DELETE', url, options);
 }

--- a/test/external-helper-method-test.js
+++ b/test/external-helper-method-test.js
@@ -1,0 +1,31 @@
+var request = require('../');
+
+// Test GET request
+console.dir('http://nodejs.org');
+var responseFromGet = request.get('http://nodejs.org');
+
+console.log(responseFromGet);
+console.log("Reponse Body Length: ", responseFromGet.getBody().length);
+
+// Test HTTPS POST request
+console.dir('https://talk.to/');
+var responseFromPost = request.post('http://httpbin.org/post', { body: '<body/>' });
+
+console.log(responseFromPost);
+console.log("Reponse Body Length: ", responseFromPost.getBody().length);
+
+console.dir('https://apache.org');
+var errored = false;
+try {
+  // Test unauthorized HTTPS GET request
+  var unAuthGetResponse = request.get('https://apache.org');
+  console.log(unAuthGetResponse);
+  console.log("Reponse Body: ", unAuthGetResponse.body.toString());
+  errored = true;
+} catch(ex) {
+  console.log("Successully rejected unauthorized host: https://apache.org/");
+}
+if (errored)
+  throw new Error('Should have rejected unauthorized https get request');
+
+

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ server.on('message', function(m) {
         console.log('#############################');
 
         require('./internal-test');
+        require('./internal-helper-method-test');
 
         server.send('stop');
     } else {
@@ -18,6 +19,7 @@ server.on('message', function(m) {
         console.log('#############################');
 
         require('./external-test');
+        require('./external-helper-method-test');
 
         process.exit(0);
     }

--- a/test/internal-helper-method-test.js
+++ b/test/internal-helper-method-test.js
@@ -1,0 +1,30 @@
+var request = require('../');
+
+// Test GET helper request
+console.log('GET using helper method', 'http://localhost:3030/internal-test');
+var responseFromGet = request.get('http://localhost:3030/internal-test', {timeout: 2000});
+
+console.log(responseFromGet);
+console.log("Reponse Body Length from GET helper: ", responseFromGet.getBody().length);
+
+// Test HTTPS POST request
+console.log('POST', 'http://localhost:3030/internal-test');
+var responseFromPost = request.post('http://localhost:3030/internal-test', {timeout: 2000, body: '<body/>' });
+
+console.log(responseFromPost);
+console.log("Reponse Body Length: ", responseFromPost.getBody().length);
+
+// Test PUT request
+console.log('PUT', 'http://localhost:3030/internal-test');
+var responseFromPut = request.put('http://localhost:3030/internal-test', {timeout: 2000, body: '<body/>' });
+
+console.log(responseFromPut);
+console.log("Reponse Body Length: ", responseFromPut.getBody().length);
+
+// Test HTTPS DELETE request
+console.log('DELETE', 'http://localhost:3030/internal-test');
+var responseFromDelete = request.delete('http://localhost:3030/internal-test', {timeout: 2000});
+
+console.log(responseFromDelete);
+console.log("Reponse Body Length: ", responseFromDelete.getBody().length);
+

--- a/test/internal-helper-method-test.js
+++ b/test/internal-helper-method-test.js
@@ -1,30 +1,29 @@
 var request = require('../');
 
 // Test GET helper request
-console.log('GET using helper method', 'http://localhost:3030/internal-test');
+console.log('GET using get helper method', 'http://localhost:3030/internal-test');
 var responseFromGet = request.get('http://localhost:3030/internal-test', {timeout: 2000});
 
 console.log(responseFromGet);
-console.log("Reponse Body Length from GET helper: ", responseFromGet.getBody().length);
+console.log("Reponse Body Length: ", responseFromGet.getBody().length);
 
 // Test HTTPS POST request
-console.log('POST', 'http://localhost:3030/internal-test');
+console.log('POST using post helper method', 'http://localhost:3030/internal-test');
 var responseFromPost = request.post('http://localhost:3030/internal-test', {timeout: 2000, body: '<body/>' });
 
 console.log(responseFromPost);
 console.log("Reponse Body Length: ", responseFromPost.getBody().length);
 
 // Test PUT request
-console.log('PUT', 'http://localhost:3030/internal-test');
+console.log('PUT using put helper method', 'http://localhost:3030/internal-test');
 var responseFromPut = request.put('http://localhost:3030/internal-test', {timeout: 2000, body: '<body/>' });
 
 console.log(responseFromPut);
 console.log("Reponse Body Length: ", responseFromPut.getBody().length);
 
 // Test HTTPS DELETE request
-console.log('DELETE', 'http://localhost:3030/internal-test');
+console.log('DELETE using delete helper method', 'http://localhost:3030/internal-test');
 var responseFromDelete = request.delete('http://localhost:3030/internal-test', {timeout: 2000});
 
 console.log(responseFromDelete);
 console.log("Reponse Body Length: ", responseFromDelete.getBody().length);
-


### PR DESCRIPTION
A small commit, which adds convenience methods for GET, POST, PUT, DELETE on the main request object. 

This is to help myself in my current testing workflow (mocha + sinon) but are also present on the original 'request' project for similar reasons.