### PR TITLE
stdio: ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ logs
 results
 npm-debug.log
 node_modules
+.idea

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function start() {
         throw findPortResult.error;
       }
       const ncPort = findPortResult.stdout.toString('utf8').trim();
-      const p = spawn(process.execPath, [require.resolve('./lib/nc-server'), ncPort], {stdio: 'inherit'});
+      const p = spawn(process.execPath, [require.resolve('./lib/nc-server'), ncPort], {stdio: 'ignore'});
       p.unref();
       process.on('exit', () => {
         p.kill();


### PR DESCRIPTION
```javascript
// input => req,  output => res
var res = spawnSync(command, args, {input: req});
```

so don't inherit IO from parent process.