### PR TITLE
Fixes a bug in cross domain handling.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -28,7 +28,7 @@ function doRequest(method, url, options) {
   // handle cross domain
 
   var match;
-  var crossDomain = !!((match = /^([\w-]+:)?\/\/([^\/]+)/.exec(options.uri)) && (match[2] != location.host));
+  var crossDomain = !!((match = /^([\w-]+:)?\/\/([^\/]+)/.exec(url)) && (match[2] != location.host));
   if (!crossDomain) options.headers['X-Requested-With'] = 'XMLHttpRequest';
 
   // handle query string


### PR DESCRIPTION
Based on the documentation and the rest of this function, there is no `options.uri`.  I suspect this was missed as part of some previous refactor that moved the URI to its own variable?